### PR TITLE
✨ Refactor Calendar

### DIFF
--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -1,0 +1,40 @@
+import "react-big-calendar/lib/css/react-big-calendar.css";
+
+import { setHours, setMinutes } from "date-fns";
+
+import { Calendar as RBCCalendar } from "react-big-calendar";
+
+import { localizer } from "./localizer";
+import { formatter } from "./formatter";
+
+export function Calendar({ day, events, onSelectEvent }) {
+  const startHourDay = setMinutes(setHours(day, 7), 0);
+
+  const endHourDay = setMinutes(setHours(day, 20), 40);
+
+  function getEventStyles(event) {
+    return {
+      style: {
+        background: event.color,
+        borderColor: "transparent",
+      },
+    };
+  }
+
+  return (
+    <RBCCalendar
+      defaultView="day"
+      date={day}
+      min={startHourDay}
+      max={endHourDay}
+      localizer={localizer}
+      events={events}
+      step={10}
+      timeslots={1}
+      toolbar={false}
+      eventPropGetter={getEventStyles}
+      onSelectEvent={onSelectEvent}
+      formats={formatter}
+    />
+  );
+}

--- a/src/components/Calendar/formatter.js
+++ b/src/components/Calendar/formatter.js
@@ -1,0 +1,7 @@
+import { format } from "date-fns";
+
+function eventTimeRangeFormat(range) {
+  return `${format(range.start, "HH:mm")}`;
+}
+
+export const formatter = { eventTimeRangeFormat };

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -1,0 +1,1 @@
+export * from "./Calendar";

--- a/src/components/Calendar/localizer.js
+++ b/src/components/Calendar/localizer.js
@@ -1,0 +1,16 @@
+import { dateFnsLocalizer } from "react-big-calendar";
+
+import { format, getDay, parse, startOfWeek } from "date-fns";
+import { ptBR } from "date-fns/locale";
+
+const locales = {
+  "pt-BR": ptBR,
+};
+
+export const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek,
+  getDay,
+  locales,
+});

--- a/src/pages/editions/[slug]/index.js
+++ b/src/pages/editions/[slug]/index.js
@@ -1,26 +1,15 @@
-import "react-big-calendar/lib/css/react-big-calendar.css";
+import { useEffect, useState } from "react";
 
 import { useRouter } from "next/router";
-import { trpc } from "../../../ultis/trpc";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { getEvents } from "../../../api/event";
+import { trpc } from "../../../ultis/trpc";
+
 import { Menu } from "../../../components/Menu/Menu";
-
-import { useEffect, useState } from "react";
-
-import { Calendar, dateFnsLocalizer } from "react-big-calendar";
-
-import { ptBR } from "date-fns/locale";
-import {
-  format,
-  getDay,
-  parse,
-  setHours,
-  setMinutes,
-  startOfWeek,
-} from "date-fns";
 import { EditionTab } from "../../../components/EditionTab/EditionTab";
+import { Calendar } from "../../../components/Calendar/Calendar";
 
 export default function EditionDetails() {
   const router = useRouter();
@@ -45,18 +34,6 @@ export default function EditionDetails() {
     return "loading...";
   }
 
-  const locales = {
-    "pt-BR": ptBR,
-  };
-
-  const localizer = dateFnsLocalizer({
-    format,
-    parse,
-    startOfWeek,
-    getDay,
-    locales,
-  });
-
   const events = getEventsResponse?.data.map((event) => ({
     id: event._id,
     title: event.title,
@@ -64,6 +41,8 @@ export default function EditionDetails() {
     end: new Date(event.endDate),
     color: event.color,
   }));
+
+  console.log(calendarDate);
 
   return (
     <div>
@@ -75,29 +54,7 @@ export default function EditionDetails() {
         onChange={handleOnEditionTabChange}
       />
 
-      {events && (
-        <Calendar
-          style={{ height: "100vh" }}
-          localizer={localizer}
-          date={calendarDate}
-          timeslots={1}
-          step={10}
-          min={setMinutes(setHours(calendarDate, 7), 0)}
-          max={setMinutes(setHours(calendarDate, 20), 40)}
-          defaultView="day"
-          events={events}
-          toolbar={false}
-          formats={{
-            eventTimeRangeFormat: (range) => `${format(range.start, "HH:mm")}`,
-          }}
-          eventPropGetter={(event) => ({
-            style: {
-              background: event.color,
-              borderColor: "transparent",
-            },
-          })}
-        />
-      )}
+      {events && <Calendar day={calendarDate} events={events} />}
     </div>
   );
 }

--- a/src/pages/editions/[slug]/index.js
+++ b/src/pages/editions/[slug]/index.js
@@ -42,8 +42,6 @@ export default function EditionDetails() {
     color: event.color,
   }));
 
-  console.log(calendarDate);
-
   return (
     <div>
       <Menu label={edition.data.name} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,18 +8,6 @@ import { useRouter } from "next/router";
 import { Fab } from "@mui/material";
 import { AddRounded } from "@mui/icons-material";
 
-import {
-  format,
-  getDay,
-  parse,
-  setHours,
-  setMinutes,
-  startOfWeek,
-} from "date-fns";
-import { ptBR } from "date-fns/locale";
-
-import { Calendar, dateFnsLocalizer } from "react-big-calendar";
-
 import { useQuery } from "@tanstack/react-query";
 
 import { getEvents } from "../api/event";
@@ -27,6 +15,7 @@ import { trpc } from "../ultis/trpc";
 
 import { Menu } from "../components/Menu/Menu";
 import { EditionTab } from "../components/EditionTab/EditionTab";
+import { Calendar } from "../components/Calendar/Calendar";
 
 import { usePermission } from "../hook/usePermission";
 
@@ -43,18 +32,6 @@ export default function Schedule() {
   function handleOnEditionTabChange(tab) {
     setCalendarDate(new Date(tab));
   }
-
-  const locales = {
-    "pt-BR": ptBR,
-  };
-
-  const localizer = dateFnsLocalizer({
-    format,
-    parse,
-    startOfWeek,
-    getDay,
-    locales,
-  });
 
   const events = getEventsResponse?.data.map((event) => ({
     id: event._id,
@@ -94,26 +71,9 @@ export default function Schedule() {
 
       {events && (
         <Calendar
-          style={{ height: "100vh" }}
-          localizer={localizer}
-          date={calendarDate}
-          timeslots={1}
-          step={10}
-          min={setMinutes(setHours(calendarDate, 7), 0)}
-          max={setMinutes(setHours(calendarDate, 20), 40)}
-          defaultView="day"
+          day={calendarDate}
           events={events}
-          toolbar={false}
           onSelectEvent={handleOnSelectEvent}
-          formats={{
-            eventTimeRangeFormat: (range) => `${format(range.start, "HH:mm")}`,
-          }}
-          eventPropGetter={(event) => ({
-            style: {
-              background: event.color,
-              borderColor: "transparent",
-            },
-          })}
         />
       )}
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,3 @@
-import "react-big-calendar/lib/css/react-big-calendar.css";
-
 import { useEffect, useState } from "react";
 
 import Link from "next/link";


### PR DESCRIPTION
# ✨ Refactor Calendar

## Motivation
After migrating the Calendar to `react-big-calendar` we now created a new component to abstract with the application rules

## Changes
- create `Calendar` component
- create supporting files to `Calendar
- apply on `/` and `/editions/[slug]` routes