### PR TITLE
✨ Improve calendar styles

### DIFF
--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -17,6 +17,19 @@ export function Calendar({ day, events, onSelectEvent }) {
       style: {
         background: event.color,
         borderColor: "transparent",
+        fontSize: 13,
+        fontWeight: 600,
+      },
+    };
+  }
+
+  function getHourStyles() {
+    return {
+      style: {
+        fontSize: 12,
+        fontWeight: 600,
+        color: "#9e9e9e",
+        marginLeft: 8,
       },
     };
   }
@@ -33,6 +46,7 @@ export function Calendar({ day, events, onSelectEvent }) {
       timeslots={1}
       toolbar={false}
       eventPropGetter={getEventStyles}
+      slotPropGetter={getHourStyles}
       onSelectEvent={onSelectEvent}
       formats={formatter}
     />

--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -17,7 +17,7 @@ export function Calendar({ day, events, onSelectEvent }) {
       style: {
         background: event.color,
         borderColor: "transparent",
-        fontSize: 13,
+        fontSize: 14,
         fontWeight: 600,
       },
     };

--- a/src/components/Calendar/formatter.js
+++ b/src/components/Calendar/formatter.js
@@ -1,7 +1,13 @@
 import { format } from "date-fns";
 
 function eventTimeRangeFormat(range) {
-  return `${format(range.start, "HH:mm")}`;
+  const { start, end } = range;
+
+  return `${format(start, "HH:mm")} - ${format(end, "HH:mm")}`;
 }
 
-export const formatter = { eventTimeRangeFormat };
+function timeGutterFormat(date) {
+  return `${format(date, "HH:mm")}`;
+}
+
+export const formatter = { eventTimeRangeFormat, timeGutterFormat };


### PR DESCRIPTION
# ✨ Improve calendar styles

## Motivation
The calendar does not feel modern like the previous library, so we need to improve the current styles as it is totally customisable

## Changes
- decrease font sizes
- apply bold style to event texts
- apply light gray color on hour texts
- format hours to 24h 
- add ending hour to event

## Screenshots
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/bbb1ec95-57da-4f19-9e4e-63cdffb1825f) | ![image](https://github.com/user-attachments/assets/61a3d5f8-8248-40dc-bdb9-b35dc338163f) |