### PR TITLE
🐛  Adjust calendar tab state

### DIFF
--- a/src/pages/editions/[slug]/index.js
+++ b/src/pages/editions/[slug]/index.js
@@ -25,10 +25,10 @@ export default function EditionDetails() {
   }
 
   useEffect(() => {
-    if (edition.data) {
+    if (!calendarDate && edition.data) {
       setCalendarDate(edition.data.startDate);
     }
-  }, [edition.data]);
+  }, [calendarDate, edition.data]);
 
   if (!edition.data) {
     return "loading...";

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -48,10 +48,10 @@ export default function Schedule() {
   }
 
   useEffect(() => {
-    if (edition.data) {
+    if (!calendarDate && edition.data) {
       setCalendarDate(edition.data.startDate);
     }
-  }, [edition.data]);
+  }, [calendarDate, edition.data]);
 
   if (!edition.data) {
     return "loading...";


### PR DESCRIPTION
# 🐛  Adjust calendar tab state

## Motivation
In order to keep the selected tab data, we should have a better control of request response

## Changes
- add condition to only set value on state when it is empty