### PR TITLE
✨ List events by edition

### DIFF
--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -12,6 +12,14 @@ export function Calendar({ day, events, onSelectEvent }) {
 
   const endHourDay = setMinutes(setHours(day, 20), 40);
 
+  const data = events.map((event) => ({
+    id: event._id,
+    title: event.title,
+    start: new Date(event.startDate),
+    end: new Date(event.endDate),
+    color: event.color,
+  }));
+
   function getEventStyles(event) {
     return {
       style: {
@@ -41,7 +49,7 @@ export function Calendar({ day, events, onSelectEvent }) {
       min={startHourDay}
       max={endHourDay}
       localizer={localizer}
-      events={events}
+      events={data}
       step={10}
       timeslots={1}
       toolbar={false}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,9 +6,6 @@ import { useRouter } from "next/router";
 import { Fab } from "@mui/material";
 import { AddRounded } from "@mui/icons-material";
 
-import { useQuery } from "@tanstack/react-query";
-
-import { getEvents } from "../api/event";
 import { trpc } from "../ultis/trpc";
 
 import { Menu } from "../components/Menu/Menu";
@@ -21,23 +18,13 @@ export default function Schedule() {
   const { push } = useRouter();
   const { isAdmin } = usePermission();
 
-  const { data: getEventsResponse } = useQuery(["events"], getEvents);
-
-  const edition = trpc.edition.getByActive.useQuery();
+  const { data } = trpc.event.get.useQuery();
 
   const [calendarDate, setCalendarDate] = useState();
 
   function handleOnEditionTabChange(tab) {
     setCalendarDate(new Date(tab));
   }
-
-  const events = getEventsResponse?.data.map((event) => ({
-    id: event._id,
-    title: event.title,
-    start: new Date(event.startDate),
-    end: new Date(event.endDate),
-    color: event.color,
-  }));
 
   function handleOnSelectEvent(event) {
     if (!isAdmin) {
@@ -48,29 +35,29 @@ export default function Schedule() {
   }
 
   useEffect(() => {
-    if (!calendarDate && edition.data) {
-      setCalendarDate(edition.data.startDate);
+    if (!calendarDate && data) {
+      setCalendarDate(data.edition.startDate);
     }
-  }, [calendarDate, edition.data]);
+  }, [calendarDate, data]);
 
-  if (!edition.data) {
+  if (!data) {
     return "loading...";
   }
 
   return (
     <div>
-      <Menu label={edition.data.name} />
+      <Menu label={data.edition.name} />
 
       <EditionTab
-        start={edition.data.startDate.toISOString()}
-        end={edition.data.endDate.toISOString()}
+        start={data.edition.startDate.toISOString()}
+        end={data.edition.endDate.toISOString()}
         onChange={handleOnEditionTabChange}
       />
 
-      {events && (
+      {calendarDate && (
         <Calendar
           day={calendarDate}
-          events={events}
+          events={data.events}
           onSelectEvent={handleOnSelectEvent}
         />
       )}

--- a/src/server/repository/EventRepository.js
+++ b/src/server/repository/EventRepository.js
@@ -42,6 +42,18 @@ export async function findByStartDate(date) {
   return events;
 }
 
+export async function findByDateRange(start, end) {
+  const db = await getDatabase();
+
+  const events = await db
+    .collection("eventos")
+    .find({ startDate: { $gte: start }, endDate: { $lte: end } })
+    .sort({ startDate: 1 })
+    .toArray();
+
+  return events;
+}
+
 export async function edit(event) {
   const db = await getDatabase();
 

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -1,8 +1,11 @@
 import { router } from "../trpc";
+
 import { editionRouter } from "./editions";
+import { eventsRouter } from "./events";
 
 export const appRouter = router({
   edition: editionRouter,
+  event: eventsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/routers/events.ts
+++ b/src/server/routers/events.ts
@@ -1,0 +1,21 @@
+import { endOfDay } from "date-fns";
+
+import { procedure, router } from "../trpc";
+
+import * as editionRepository from "../repository/EditionRepository";
+import * as eventRepository from "../repository/EventRepository";
+
+export const eventsRouter = router({
+  get: procedure.query(async () => {
+    const edition = await editionRepository.findByActive(true);
+
+    const { startDate, endDate } = edition;
+
+    const events = await eventRepository.findByDateRange(
+      startDate.toISOString(),
+      endOfDay(endDate).toISOString()
+    );
+
+    return { edition, events };
+  }),
+});


### PR DESCRIPTION
# ✨ List events by edition

## Motivation
When loading the main calendar, it was getting all events from the database, so it was taking more time than needed to render the Calendar component

We want to make it straightforward rendering only the necessary data for the active edition

## Changes
- add an events trpc route
- add function to get the events by a date range on event repository
- apply the trpc route on main calendar
- adjust data transformation on Calendar