### PR TITLE
🐛 Add route to list a past edition events by editionid

### DIFF
--- a/src/pages/editions/[slug]/index.js
+++ b/src/pages/editions/[slug]/index.js
@@ -11,7 +11,7 @@ import { Calendar } from "../../../components/Calendar/Calendar";
 export default function EditionDetails() {
   const router = useRouter();
 
-  const { data } = trpc.event.get.useQuery();
+  const { data } = trpc.event.getByEditionId.useQuery(String(router.query.slug));
 
   const [calendarDate, setCalendarDate] = useState();
 

--- a/src/server/routers/events.ts
+++ b/src/server/routers/events.ts
@@ -1,5 +1,7 @@
 import { endOfDay } from "date-fns";
 
+import * as yup from "yup";
+
 import { procedure, router } from "../trpc";
 
 import * as editionRepository from "../repository/EditionRepository";
@@ -8,6 +10,18 @@ import * as eventRepository from "../repository/EventRepository";
 export const eventsRouter = router({
   get: procedure.query(async () => {
     const edition = await editionRepository.findByActive(true);
+
+    const { startDate, endDate } = edition;
+
+    const events = await eventRepository.findByDateRange(
+      startDate.toISOString(),
+      endOfDay(endDate).toISOString()
+    );
+
+    return { edition, events };
+  }),
+  getByEditionId: procedure.input(yup.string()).query(async (opts) => {
+    const edition = await editionRepository.findById(opts.input);
 
     const { startDate, endDate } = edition;
 


### PR DESCRIPTION
# 🐛 Add route to list a past edition events by editionid

## Motivation
In #46 was missing to list the events by edition id from the URL

## Changes
- add new route for events
- apply on past edition page